### PR TITLE
Search Bar Input Issue

### DIFF
--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -8,21 +8,23 @@ interface SearchBarProps {
 const SearchBar: React.FC<SearchBarProps> = ({ targetPath }) =>{
   const location = useLocation();
   const navigate = useNavigate();
-  const [queries, setQueries] = useState<string[]>([]);
+  const [queryText, setQueryText] = useState<string>("");
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const allQ = params.getAll("q");
-    setQueries(allQ.length > 0 ? allQ : []);
+    setQueryText(allQ.join("\n"));
   }, [location.search]);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const params = new URLSearchParams();
 
-    queries.forEach((query) => {
-      if (query.trim()) params.append("q", query.trim());
-    });
+    queryText
+      .split(/\n/) 
+      .map((q) => q.trim()) 
+      .filter((q) => q.length > 0) 
+      .forEach((q) => params.append("q", q));
     const path = targetPath ?? location.pathname;
     navigate(`${path}?${params.toString()}`);
   };
@@ -33,15 +35,9 @@ const SearchBar: React.FC<SearchBarProps> = ({ targetPath }) =>{
       className="flex flex-col items-center gap-4 w-full px-4"
     >
       <textarea
-        value={queries.join("\n")}
+        value={queryText}
         onChange={(e) =>
-          setQueries(
-            e.target.value
-              .split(/\n/)
-              .map((q) => q.trim())
-              .filter((q) => q.length > 0)
-          )
-        }
+          setQueryText(e.target.value)}
         placeholder="Paste course descriptions here..."
         className="bg-blue-100 w-full max-w-3xl h-48 text-lg px-4 py-3 border border-gray-300 rounded-lg shadow-md resize-y focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-700"
       />


### PR DESCRIPTION
## Description

This PR fixes two major input issues in the search bar:
- Shift+Enter now correctly creates a new line inside the textarea.
- Space bar now properly inserts spaces without being trimmed away while typing.

The solution was to store the textarea input as raw text in a single state variable and process trimming/splitting only during form submission.

---

## Frontend Changes

### General
- Improved search bar usability by preserving user input formatting (spaces and line breaks).

### SearchBar.tsx
- Replaced `queries: string[]` state with `queryText: string`.
- Updated `useEffect` to restore queries with line breaks using `join("\n")`.
- Adjusted `onSubmit` to split, trim, and filter queries only when submitting.
- Simplified `<textarea>` to use raw input value and `onChange` handler.